### PR TITLE
angular7-example-app to 7.0.78

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: angular7-example-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.77
+  version: 7.0.78
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote angular7-example-app to version 7.0.78